### PR TITLE
Barfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This build is not intended for submission, but rather for the developers to keep
   - Or they could pay rent to another player even though they own the property.
   - Or they move to the wrong field.
 - On the player info, you can see how drunk the current player is.
+- A bug where the game crashed when you're drunk and the owner of the field is non-existant has been fixed.
     
 ## Known issues
 

--- a/main.py
+++ b/main.py
@@ -191,7 +191,7 @@ def rollDices(players=players):
             
         player_buys_anyway = random.randint(0, 1)
             
-        if player_drunk and player_buys_anyway == 1:
+        if player_drunk and player_buys_anyway == 1 and fc.f_container[player.fid].owner != None:
             if fc.f_container[player.fid].owner.name == player.name:
                 player.balance -= fc.f_container[player.fid].rent
                 players[list(players.keys())[((turns -1) % len(players)) + 1]].balance += fc.f_container[player.fid].rent


### PR DESCRIPTION
Bugfix: The game no longer crashes when a drunk player "should pay rent to a non-existant owner". No approval required.